### PR TITLE
qt5-centos7: Optimize image size

### DIFF
--- a/Docker/qt5-centos7/Dockerfile
+++ b/Docker/qt5-centos7/Dockerfile
@@ -75,9 +75,11 @@ RUN \
   ./qt-unified-linux-x64-online.run --verbose --platform minimal --script ./qt-installer-noninteractive.qs && \
   rm -f qt-installer-noninteractive.qs qt-unified-linux-x64-online.run && \
   #
-  # Cleanup unneeded Qt directories and files
+  # Cleanup
   #
   find /opt/qt -maxdepth 1 -type f -exec rm -rf "{}" \; && \
+  find /opt/qt -type f -name "*.debug" -delete && \
+  find /opt/qt/5.11.0/gcc_64/bin -type f -executable -exec strip {} \; && \
   rm -rf \
     /opt/qt/dist \
     /opt/qt/Docs \

--- a/Docker/qt5-centos7/Dockerfile
+++ b/Docker/qt5-centos7/Dockerfile
@@ -89,14 +89,6 @@ RUN \
   #
   yum clean all
 
-# XXX Install https://github.com/dockbuild/ninja-jobserver
-#     If it works well, it will be added to the base image.
-RUN \
-  curl -LO https://github.com/dockbuild/ninja-jobserver/releases/download/v1.8.2-jobserver/ninja-jobserver-linux.zip && \
-  unzip ninja-jobserver-linux.zip && \
-  mv ninja /usr/local/bin/ninja && \
-  rm -f ninja-jobserver-linux.zip
-
 #
 # (1) Add Qt root directory to the PATH. This allows CMake command
 #     'find_package(Qt5 REQUIRED)` to succeed.

--- a/README.rst
+++ b/README.rst
@@ -55,7 +55,7 @@ slicer/buildenv-qt4-centos5:latest
   :target: https://microbadger.com/images/slicer/buildenv-qt5-centos7:latest
 
 slicer/buildenv-qt5-centos7:latest
-  |buildenv-qt5-centos7-latest| Build environment based on Centos7 and including Qt 5.10.1
+  |buildenv-qt5-centos7-latest| Build environment based on Centos7 and including Qt 5.11.0
 
 
 Visual Overview


### PR DESCRIPTION

Uncompressed sizes:
* Qt 5.10.1 was 1.1GB
* Qt 5.11.0 is now 1.4 GB (instead of 3.5GB)

Compressed size:
* Qt 5.10.1 was ~393MB
* Qt 5.11.0 is now ~460MB (instead of 1.5GB)

For reference:

_command executed after starting bash in the image_

### Qt 5.11.0: Before

```
cd /opt/qt/5.11.0/gcc_64
du -h | grep -E "\./\w+$"
3.3M	./mkspecs
540M	./plugins
404M	./bin
2.5G	./lib
162M	./qml
320K	./phrasebooks
47M	./include
564K	./doc
20M	./resources
27M	./translations
264K	./libexec
```

### Qt 5.11.0: After

```
cd /opt/qt/5.11.0/gcc_64
du -h | grep -E "\./\w+$"
31M	./plugins
83M	./bin
428M	./lib
21M	./qml
3.3M	./mkspecs
320K	./phrasebooks
47M	./include
564K	./doc
20M	./resources
27M	./translations
264K	./libexec
```

### Qt 5.10.1: Size associated with Qt5.10.1 image

```
cd /opt/qt/5.10.1/gcc_64
du -h | grep -E "\./\w+$"
3.2M	./mkspecs
22M	./plugins
42M	./bin
209M	./lib
22M	./qml
320K	./phrasebooks
45M	./include
564K	./doc
21M	./resources
28M	./translations
16K	./libexec
```