### PR TITLE
qt5-centos7: Install libuuid needed by to build SlicerJupyter extension

### DIFF
--- a/Docker/qt5-centos7/Dockerfile
+++ b/Docker/qt5-centos7/Dockerfile
@@ -67,6 +67,12 @@ RUN \
     subversion \
   && \
   #
+  # SlicerJupyter dependencies
+  #
+  yum install -y \
+    libuuid-devel \
+  && \
+  #
   # Download and install Qt
   #
   cd /usr/src && \


### PR DESCRIPTION
Suggested-by: Isaiah Norton <inorton@bwh.harvard.edu>