### PR TITLE
qt5-centos7: Update from 5.12.8 to 5.15.0

### DIFF
--- a/Docker/qt5-centos7/Dockerfile
+++ b/Docker/qt5-centos7/Dockerfile
@@ -89,7 +89,7 @@ RUN \
   #
   find /opt/qt -maxdepth 1 -type f -exec rm -rf "{}" \; && \
   find /opt/qt -type f -name "*.debug" -delete && \
-  find /opt/qt/5.12.8/gcc_64/bin -type f -executable -exec strip {} \; && \
+  find /opt/qt/5.15.0/gcc_64/bin -type f -executable -exec strip {} \; && \
   rm -rf \
     /opt/qt/dist \
     /opt/qt/Docs \
@@ -108,8 +108,8 @@ RUN \
 # (2) Set env. variable Qt5_DIR to support configuring project
 #     by explicitly passing -DQt5_DIR:PATH=${Qt5_DIR}
 #
-ENV PATH=/opt/qt/5.12.8/gcc_64/:${PATH} \
-    Qt5_DIR=/opt/qt/5.12.8/gcc_64/lib/cmake/Qt5
+ENV PATH=/opt/qt/5.15.0/gcc_64/:${PATH} \
+    Qt5_DIR=/opt/qt/5.15.0/gcc_64/lib/cmake/Qt5
 
 # Build-time metadata as defined at http://label-schema.org
 ARG BUILD_DATE

--- a/Docker/qt5-centos7/qt-installer-noninteractive.qs
+++ b/Docker/qt5-centos7/qt-installer-noninteractive.qs
@@ -69,14 +69,14 @@ Controller.prototype.ComponentSelectionPageCallback = function() {
     widget.deselectAll();
 
     //widget.selectComponent("qt");
-    //widget.selectComponent("qt.qt5.5128");
-    widget.selectComponent("qt.qt5.5128.gcc_64");
-    widget.selectComponent("qt.qt5.5128.qtscript");
-    widget.selectComponent("qt.qt5.5128.qtscript.gcc_64");
-    widget.selectComponent("qt.qt5.5128.qtwebengine");
-    widget.selectComponent("qt.qt5.5128.qtwebengine.gcc_64");
-    //widget.selectComponent("qt.qt5.5128.qtwebglplugin");
-    //widget.selectComponent("qt.qt5.5128.qtwebglplugin.gcc_64");
+    //widget.selectComponent("qt.qt5.5150");
+    widget.selectComponent("qt.qt5.5150.gcc_64");
+    widget.selectComponent("qt.qt5.5150.qtscript");
+    widget.selectComponent("qt.qt5.5150.qtscript.gcc_64");
+    widget.selectComponent("qt.qt5.5150.qtwebengine");
+    widget.selectComponent("qt.qt5.5150.qtwebengine.gcc_64");
+    //widget.selectComponent("qt.qt5.5150.qtwebglplugin");
+    //widget.selectComponent("qt.qt5.5150.qtwebglplugin.gcc_64");
     //widget.selectComponent("qt.tools");
 
     gui.clickButton(buttons.NextButton);

--- a/README.rst
+++ b/README.rst
@@ -62,7 +62,7 @@ slicer/buildenv-qt5-centos7:slicer-4.10
   :target: https://microbadger.com/images/slicer/buildenv-qt5-centos7:latest
 
 slicer/buildenv-qt5-centos7:latest
-  |buildenv-qt5-centos7-latest| Build environment based on Centos7 and including Qt 5.12.8
+  |buildenv-qt5-centos7-latest| Build environment based on Centos7 and including Qt 5.15.0
 
 
 Visual Overview


### PR DESCRIPTION
This updates qt5-centos7 to use Qt 5.15.0

From ToDo list in:
https://discourse.slicer.org/t/build-failure-windows/7322/37